### PR TITLE
Hopefully fixed problems with missing specialized database entries

### DIFF
--- a/backend/tomato/elements/__init__.py
+++ b/backend/tomato/elements/__init__.py
@@ -467,8 +467,12 @@ def create(top, type_, parent=None, attrs={}):
 	top.checkRole(Role.manager)	
 	fault.check(type_ in TYPES, "Unsupported type: %s", type_)
 	el = TYPES[type_]()
-	el.init(top, parent, attrs)
-	el.save()
+	try:
+		el.init(top, parent, attrs)
+		el.save()
+	except:
+		el.remove()
+		raise
 	if parent:
 		parent.onChildAdded(el)
 	logging.logMessage("create", category="element", id=el.id)	

--- a/backend/tomato/resources/__init__.py
+++ b/backend/tomato/resources/__init__.py
@@ -166,8 +166,12 @@ def create(type_, attrs={}):
         res = TYPES[type_]()
     else:
         res = Resource(type=type_)
-    res.init(attrs)
-    res.save()
+    try:
+        res.init(attrs)
+        res.save()
+    except:
+        res.remove()
+        raise
     return res
 
 def init():

--- a/hostmanager/tomato/connections/__init__.py
+++ b/hostmanager/tomato/connections/__init__.py
@@ -336,8 +336,12 @@ def create(el1, el2, type_=None, attrs={}):
 	if type_:
 		fault.check(type_ in TYPES, "Unsupported type: %s", type_)
 		con = TYPES[type_]()
-		con.init(el1, el2, attrs)
-		con.save()
+		try:
+			con.init(el1, el2, attrs)
+			con.save()
+		except:
+			con.remove()
+			raise
 		logging.logMessage("create", category="connection", id=con.id)	
 		logging.logMessage("info", category="connection", id=con.id, info=con.info())	
 		return con

--- a/hostmanager/tomato/elements/__init__.py
+++ b/hostmanager/tomato/elements/__init__.py
@@ -447,8 +447,12 @@ def create(type_, parent=None, attrs={}):
 	fault.check(type_ in TYPES, "Unsupported type: %s", type_)
 	fault.check(not parent or parent.owner == currentUser(), "Parent element belongs to different user")
 	el = TYPES[type_]()
-	el.init(parent, attrs)
-	el.save()
+	try:
+		el.init(parent, attrs)
+		el.save()
+	except:
+		el.remove()
+		raise
 	if parent:
 		parent.onChildAdded(el)
 	logging.logMessage("create", category="element", id=el.id)	

--- a/hostmanager/tomato/resources/__init__.py
+++ b/hostmanager/tomato/resources/__init__.py
@@ -164,8 +164,12 @@ def create(type_, attrs={}):
         res = TYPES[type_]()
     else:
         res = Resource(type=type_)
-    res.init(attrs)
-    res.save()
+    try:
+        res.init(attrs)
+        res.save()
+    except:
+        res.remove()
+        raise
     logging.logMessage("create", category="resource", type=res.type, id=res.id, attrs=attrs)
     logging.logMessage("info", category="resource", type=res.type, id=res.id, info=res.info())
     return res


### PR DESCRIPTION
In our model inheritance there is a problem when the parent model is stored in the database but the child model is not.
This can happen when the `init` method triggers a `save` of the parent model but subsequently fails and thus does not save the child model.
