### PR TITLE
fixed http-only links. they now refer to https iff the user accessed the...

### DIFF
--- a/web/tomato/templates/admin/site/form.html
+++ b/web/tomato/templates/admin/site/form.html
@@ -24,7 +24,7 @@
 			$.ajax({
 				type: "GET",
 				async: true,
-				url: "http://maps.googleapis.com/maps/api/geocode/json?sensor=false&address="+addr,
+				url: "//maps.googleapis.com/maps/api/geocode/json?sensor=false&address="+addr,
 				success: function(res) {
 					var ret = res.results[0];
 					if(ret) {

--- a/web/tomato/templates/base.html
+++ b/web/tomato/templates/base.html
@@ -9,7 +9,7 @@
 <meta name="DESCRIPTION" content="German Lab Webpage" /> 
 
 <link href="/style/style.css" rel="stylesheet" type="text/css" /> 
-<link rel="shortcut icon" type="image/x-icon" href="http://www.german-lab.de/favicon.ico" />
+<link rel="shortcut icon" type="image/x-icon" href="//www.german-lab.de/favicon.ico" />
 
 {% load tomato %}
 
@@ -42,7 +42,7 @@ head.appendChild(style);
 	<div id="header"> 
 		<div id="minimenu_top" class="smallmenu"></div> 
 		<div id="logo_glab">
-			<a href="http://www.german-lab.de"><img border="0" src="/style/glablogo.jpg" alt="glablogo" /></a>
+			<a href="//www.german-lab.de"><img border="0" src="/style/glablogo.jpg" alt="glablogo" /></a>
 		</div> 
 		<div id="logo_tomato">
 			<a href="/"><img src="/style/tomato_logo.png" /></a>

--- a/web/tomato/templates/element/rextfv_status.html
+++ b/web/tomato/templates/element/rextfv_status.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <link href="/style/style.css" rel="stylesheet" type="text/css" /> 
-<link rel="shortcut icon" type="image/x-icon" href="http://www.german-lab.de/favicon.ico" />
+<link rel="shortcut icon" type="image/x-icon" href="//www.german-lab.de/favicon.ico" />
 <style type="text/css">
 	body {
 		min-width:0px;

--- a/web/tomato/templates/topology/info.html
+++ b/web/tomato/templates/topology/info.html
@@ -83,7 +83,7 @@ function shrinkHeader() {
 	header.style.textAlign = "center";
 	
 	var logo = document.createElement('div')
-	logo.innerHTML='<a href="http://german-lab.de/" target="_blank"><img src="/style/glablogo.jpg" height="33" /></a>\
+	logo.innerHTML='<a href="//german-lab.de/" target="_blank"><img src="/style/glablogo.jpg" height="33" /></a>\
 					  <a href="{%url main.index%}"><img src="/style/tomato_logo.png" height="33" /></a>';
 	logo.style.float = 'left';
 	


### PR DESCRIPTION
... webfrontend via https. Ignored external links where there is no https available.

Closes #312
- www.uni-kl.de and www.icsy.de do not work via https.
