### PR TITLE
better fault when the bridge capture folder does not exist

### DIFF
--- a/hostmanager/tomato/connections/bridge.py
+++ b/hostmanager/tomato/connections/bridge.py
@@ -334,6 +334,7 @@ class Bridge(connections.Connection):
 		net.bridgeRemoveInterface(self.bridge, ifname)
 
 	def action_download_grant(self, limitSize=None):
+		fault.check(os.path.exists(self.dataPath("capture")), "Nothing captured so far")
 		entries = [os.path.join(self.dataPath("capture"), f) for f in path.entries(self.dataPath("capture"))]
 		fault.check(entries, "Nothing captured so far")
 		net.tcpslice(self.dataPath("capture.pcap"), entries, limitSize)


### PR DESCRIPTION
closes #691

at least I hope this fixes it.
the capture folder is only created when capturing is started. path.entries (i.e., os.listdir ) throws this error if the given path does not exist.

I could not test this, because my testing host has some problems (@dswd, can you take a look at glab.50 ?).
