### PR TITLE
Topology init name

### DIFF
--- a/web/tomato/js/editor.js
+++ b/web/tomato/js/editor.js
@@ -1855,7 +1855,6 @@ var Topology = Class.extend({
 				}
 			}
 		}));
-		name.setValue(t.attrs.name);
 		var choices = {};
 		var timeout_settings = t.editor.options.timeout_settings;
 		for (var i = 0; i < timeout_settings.options.length; i++) choices[timeout_settings.options[i]] = formatDuration(timeout_settings.options[i]); 
@@ -4015,7 +4014,8 @@ var Editor = Class.extend({
 							"timeout": t.options.timeout_settings["default"]
 						}});
 					} else
-						t.topology.initialDialog();
+						if (t.topology.data.attrs._initialized!=undefined)
+							t.topology.initialDialog();
 				t.workspace.updateTopologyTitle();
 			}
 		});

--- a/web/tomato/topology.py
+++ b/web/tomato/topology.py
@@ -116,6 +116,7 @@ def create(api, request):
 	if not api.user:
 		raise AuthError()
 	info=api.topology_create()
+	api.topology_modify(info['id'],{'_initialized':False})
 	return redirect("tomato.topology.info", id=info["id"])
 
 @wrap_rpc


### PR DESCRIPTION
If _initialized is not defined for a topology, the editor will not show the init dialog.

If it is not defined, it is assumed to be created by another client, i.e., it has been initialized.
When the editor creates a topology, it will explicitly set _initialized to false.
