### PR TITLE
cache autoupdating

### DIFF
--- a/backend/tomato/__init__.py
+++ b/backend/tomato/__init__.py
@@ -63,7 +63,7 @@ starttime = time.time()
 
 from . import resources, host, auth, rpcserver #@UnresolvedImport
 from lib.cmd import bittorrent, process #@UnresolvedImport
-from lib import util #@UnresolvedImport
+from lib import util, cache #@UnresolvedImport
 
 scheduler.scheduleRepeated(config.BITTORRENT_RESTART, util.wrap_task(bittorrent.restartClient))
 
@@ -85,6 +85,7 @@ def start():
 	scheduler.start()
 	dump.init()
 	dumpmanager.init()# important: must be called after dump.init()
+	cache.init()# this does not depend on anything (except the scheduler variable being initialized), and nothing depends on this. No need to hurry this.
 	
 def reload_(*args):
 	print >>sys.stderr, "Reloading..."

--- a/backend/tomato/lib/cache.py
+++ b/backend/tomato/lib/cache.py
@@ -15,59 +15,119 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-import time, sys
+import time, sys, threading, thread
+
+class CacheUpdater:
+	caches = []
+	lock = threading.RLock()
+	def add(self, cache):
+		with self.lock:
+			self.caches.append(cache)
+	def remove(self, cache):
+		with self.lock:
+			self.caches.remove(cache)
+	def start_updating(self, interval):
+		from .. import scheduler
+		scheduler.scheduleRepeated(interval, self.update_all, immediate=False)
+	def update_all(self):
+		with self.lock:
+			for cache in self.caches:
+				thread.start_new_thread(cache.update_all)
+cache_updater = None
 
 class Cache:
-	def __init__(self, maxSize=100, timeout=None):
-		self._values={}
-		self._order=[]
+	def __init__(self, fn, maxSize=100, timeout=None, autoupdate=False):
+		self._values={} #{key:{value, timeout, auto_timeout, args, kwargs}}
+		self._order=[]  #[key]
 		self._maxSize=maxSize
 		self._timeout=timeout
-	def __getitem__(self, key):
-		(value, timeout) = self._values[key] #This will trigger IndexError on purpose
-		if timeout >= time.time():
-			return value
-		else:
-			raise IndexError("entry has timed out")
-	def __setitem__(self, key, value):
-		if len(self._order) >= self._maxSize:
-			delkey = self._order.pop(0)
-			del self._values[delkey]
-		self._order.append(key)
-		timeout = (time.time() + self._timeout) if self._timeout else sys.maxint
-		self._values[key] = (value, timeout)
-	def __delitem__(self, key):
-		del self._values[key] #This will trigger IndexError on purpose
-		self._order.remove(key)
-	def __contains__(self, key):
-		return key in self._values
+		self._fn = fn
+		self._lock = threading.RLock()
+		self._autoupdate = autoupdate
+		self._autoupdate_registered = not self._autoupdate # registration for auto-updates will be checked when a value is set.
+															# this is false iff this cache needs to be added to the auto updater.
+	@staticmethod
+	def getKey(args, kwargs):
+		return (tuple(args), tuple(kwargs.items()))
+	def get(self, args, kwargs):
+		with self._lock:
+			key = Cache.getKey(args, kwargs)
+			if (not key in self._values) or (self._values[key]['timeout'] <= time.time()):
+				self.update(args, kwargs)
+			return self._values[Cache.getKey(args, kwargs)]['value']
+	def update(self, args, kwargs):
+		with self._lock:
+			value = self._fn(*args, **kwargs)
+			self.set(args, kwargs, value)
+	def set(self, args, kwargs, value):
+		with self._lock:
+			key = Cache.getKey(args, kwargs)
+			
+			#clear oldest entry if cache is full
+			if len(self._order) >= self._maxSize:
+				delkey = self._order.pop(0)
+				del self._values[delkey]
+				
+			#maintain order of caching
+			if key in self._values:
+				self._order.remove(key)
+			self._order.append(key)
+			
+			#save value
+			timeout = (time.time() + self._timeout) if self._timeout else sys.maxint
+			auto_timeout = timeout - 0.25*self._timeout if self._timeout else sys.maxint #auto-refresh triggers after 3/4 timeout
+			self._values[key] = {'value':value,
+								 'timeout':timeout,
+								 'auto_timeout':auto_timeout,
+								 'args':args,
+								 'kwargs':kwargs}
+		if not self._autoupdate_registered:
+			if cache_updater is not None:
+				cache_updater.add(self)
+				self._autoupdate_registered = True
+	def remove(self, args, kwargs):
+		with self._lock:
+			key = Cache.getKey(args, kwargs)
+			del self._values[key]
+			self._order.remove(key)
+	def contains(self, args, kwargs):
+		with self._lock:
+			return Cache.getKey(args, kwargs) in self._values
 	def clear(self):
-		self._values = {}
-		self._order = []
+		with self._lock:
+			self._values = {}
+			self._order = {}
+	def update_all(self):
+		if self._autoupdate:
+			for key in list(self._order): #since maxsize is bounded, this is not a scaling problem.
+				with self._lock: #release the lock between all cycles to allow other threads to step in between two iterations.
+								#this function can only change the order of entries, but does not delete any.
+					res = self._values[key]
+					if res['auto_timeout'] <= time.time():
+						self.update(res['args'], res['kwargs'])
+		
+		
 	
 class CachedMethod:
 	def __init__(self, fn, cache):
 		self._fn = fn
 		self._cache = cache
 	def __call__(self, *args, **kwargs):
-		key = (tuple(args), tuple(kwargs.items()))
-		if key in self._cache:
-			try:
-				return self._cache[key]
-			except IndexError:
-				pass
-		value = self._fn(*args, **kwargs)
-		self._cache[key] = value
-		return value
+		return self._cache.get(args, kwargs)
 	def invalidate(self):
 		self._cache.clear()	
 	
-def cached(timeout=None, cache=None, maxSize=100):
+def cached(timeout=None, cache=None, maxSize=100, autoupdate=False):
 	def wrap(fn):
-		_cache = cache if cache else Cache(timeout=timeout, maxSize=maxSize)
+		_cache = cache if cache else Cache(fn=fn, timeout=timeout, maxSize=maxSize, autoupdate=autoupdate)
 		call = CachedMethod(fn, _cache)
 		call.__name__ = fn.__name__
 		call.__doc__ = fn.__doc__
 		call.__dict__.update(fn.__dict__)
 		return call
 	return wrap
+
+def init():
+	cache_updater = CacheUpdater()
+	cache_updater.start_updating(5*60)
+	

--- a/backend/tomato/lib/cache.py
+++ b/backend/tomato/lib/cache.py
@@ -19,24 +19,20 @@ import time, sys, threading, thread
 
 class CacheUpdater:
 	caches = []
-	lock = threading.RLock()
 	def add(self, cache):
-		with self.lock:
-			self.caches.append(cache)
+		self.caches.append(cache)
 	def remove(self, cache):
-		with self.lock:
-			self.caches.remove(cache)
+		self.caches.remove(cache)
 	def start_updating(self, interval):
 		from .. import scheduler
 		scheduler.scheduleRepeated(interval, self.update_all, immediate=False)
 	def update_all(self):
-		with self.lock:
-			for cache in self.caches:
-				thread.start_new_thread(cache.update_all)
+		for cache in list(self.caches):
+			cache.update_all()
 cache_updater = None
 
 class Cache:
-	def __init__(self, fn, maxSize=100, timeout=None, autoupdate=False):
+	def __init__(self, fn=None, maxSize=100, timeout=None, autoupdate=False):
 		self._values={} #{key:{value, timeout, auto_timeout, args, kwargs}}
 		self._order=[]  #[key]
 		self._maxSize=maxSize
@@ -50,41 +46,51 @@ class Cache:
 	def getKey(args, kwargs):
 		return (tuple(args), tuple(kwargs.items()))
 	def get(self, args, kwargs):
+		key = Cache.getKey(args, kwargs)
 		with self._lock:
-			key = Cache.getKey(args, kwargs)
 			if (not key in self._values) or (self._values[key]['timeout'] <= time.time()):
 				self.update(args, kwargs)
 			return self._values[Cache.getKey(args, kwargs)]['value']
 	def update(self, args, kwargs):
+		calltime = time.time()
+		value = self._fn(*args, **kwargs) #there may be concurrent method calls here. set() will resolve this.
+		self.set(args, kwargs, value, calltime=calltime)
+	def set(self, args, kwargs, value, calltime=None):
+		key = Cache.getKey(args, kwargs)
+		if calltime is None:
+			calltime = time.time()
 		with self._lock:
-			value = self._fn(*args, **kwargs)
-			self.set(args, kwargs, value)
-	def set(self, args, kwargs, value):
-		with self._lock:
-			key = Cache.getKey(args, kwargs)
+			
+			timeout = (calltime + self._timeout) if self._timeout else sys.maxint
+			auto_timeout = timeout - 0.25*self._timeout if self._timeout else sys.maxint #auto-refresh triggers after 3/4 timeout
+			
+			#check whether another thread has accessed this function concurrently (may happen in update). If yes, do not save this.
+			if key in self._values:
+				if self._values[key]['timeout'] > timeout:
+					return
 			
 			#clear oldest entry if cache is full
 			if len(self._order) >= self._maxSize:
 				delkey = self._order.pop(0)
 				del self._values[delkey]
 				
-			#maintain order of caching
+			#make sure that this key is not in _order (it may only be once in there)
 			if key in self._values:
 				self._order.remove(key)
+				
+			#save
 			self._order.append(key)
-			
-			#save value
-			timeout = (time.time() + self._timeout) if self._timeout else sys.maxint
-			auto_timeout = timeout - 0.25*self._timeout if self._timeout else sys.maxint #auto-refresh triggers after 3/4 timeout
 			self._values[key] = {'value':value,
 								 'timeout':timeout,
 								 'auto_timeout':auto_timeout,
 								 'args':args,
 								 'kwargs':kwargs}
-		if not self._autoupdate_registered:
-			if cache_updater is not None:
-				cache_updater.add(self)
-				self._autoupdate_registered = True
+			
+			#finally, register this cache for auto-update if needed.
+			if not self._autoupdate_registered:
+				if cache_updater is not None:
+					cache_updater.add(self)
+					self._autoupdate_registered = True
 	def remove(self, args, kwargs):
 		with self._lock:
 			key = Cache.getKey(args, kwargs)
@@ -101,25 +107,29 @@ class Cache:
 		if self._autoupdate:
 			for key in list(self._order): #since maxsize is bounded, this is not a scaling problem.
 				with self._lock: #release the lock between all cycles to allow other threads to step in between two iterations.
-								#this function can only change the order of entries, but does not delete any.
-					res = self._values[key]
-					if res['auto_timeout'] <= time.time():
-						self.update(res['args'], res['kwargs'])
+								#    This function can only change the order of entries, but does not delete any.
+								# Concurrent calls may remove the first entries of the list. In this case, this function should ignore these entries.
+								#    However, there is only a really slight chance that this happens, and it doesn't lead to inconsistency.
+								#	 This only means there is no guarantee that the key is still in the list when entering the lock.
+								#        Conclusion: only do something if the key is still cached.
+					if key in self._values:
+						res = self._values[key]
+						if res['auto_timeout'] <= time.time():
+							self.update(res['args'], res['kwargs'])
 		
 		
 	
 class CachedMethod:
-	def __init__(self, fn, cache):
-		self._fn = fn
+	def __init__(self, cache):
 		self._cache = cache
 	def __call__(self, *args, **kwargs):
 		return self._cache.get(args, kwargs)
 	def invalidate(self):
 		self._cache.clear()	
 	
-def cached(timeout=None, cache=None, maxSize=100, autoupdate=False):
+def cached(timeout=None, maxSize=100, autoupdate=False):
 	def wrap(fn):
-		_cache = cache if cache else Cache(fn=fn, timeout=timeout, maxSize=maxSize, autoupdate=autoupdate)
+		_cache = Cache(fn=fn, timeout=timeout, maxSize=maxSize, autoupdate=autoupdate)
 		call = CachedMethod(fn, _cache)
 		call.__name__ = fn.__name__
 		call.__doc__ = fn.__doc__
@@ -129,5 +139,5 @@ def cached(timeout=None, cache=None, maxSize=100, autoupdate=False):
 
 def init():
 	cache_updater = CacheUpdater()
-	cache_updater.start_updating(5*60)
+	cache_updater.start_updating(5*60) #refresh every five minutes. For most caches, this usually means iterating through a list without doing anything.
 	

--- a/backend/tomato/lib/cache.py
+++ b/backend/tomato/lib/cache.py
@@ -138,6 +138,7 @@ def cached(timeout=None, maxSize=100, autoupdate=False):
 	return wrap
 
 def init():
+	global cache_updater
 	cache_updater = CacheUpdater()
 	cache_updater.start_updating(5*60) #refresh every five minutes. For most caches, this usually means iterating through a list without doing anything.
 	


### PR DESCRIPTION
Closes #881
Removed a bug where _values and _order of a cache could desync because a key was not removed from _order before appending it again.
Accesses to the cache is now synchronized.