### PR TITLE
fixed template creation

### DIFF
--- a/web/.settings/org.eclipse.core.resources.prefs
+++ b/web/.settings/org.eclipse.core.resources.prefs
@@ -6,7 +6,6 @@ encoding//tomato/admin/organization.py=utf-8
 encoding//tomato/admin/site.py=utf-8
 encoding//tomato/admin_common.py=utf-8
 encoding//tomato/ajax.py=utf-8
-encoding//tomato/connection.py=utf-8
 encoding//tomato/crispy_forms/__init__.py=utf-8
 encoding//tomato/crispy_forms/base.py=utf-8
 encoding//tomato/crispy_forms/helper.py=utf-8

--- a/web/tomato/template.py
+++ b/web/tomato/template.py
@@ -58,7 +58,7 @@ class TemplateForm(BootstrapForm):
 	creation_date = forms.DateField(required=False,widget=forms.TextInput(attrs={'class': 'datepicker'}));
 	show_as_common = forms.BooleanField(label="Show in Common Elements", help_text="Show this template in the common elements section in the editor", required=False)
 	icon = forms.URLField(label="Icon", help_text="URL of a 32x32 icon to use for elements of this template, leave empty to use the default icon", required=False)
-	kblang = forms.CharField(max_length=50,label="Keyboard Layout",widget = forms.widgets.Select(choices=kblang_options))
+	kblang = forms.CharField(max_length=50,label="Keyboard Layout",widget = forms.widgets.Select(choices=kblang_options), help_text="Only for KVM templates", required=False)
 	def __init__(self, *args, **kwargs):
 		super(TemplateForm, self).__init__(*args, **kwargs)
 		self.fields['creation_date'].initial=datetime.date.today()
@@ -81,11 +81,19 @@ class AddTemplateForm(TemplateForm):
             'show_as_common',
             'restricted',
             'nlXTP_installed',
+            'kblang',
             'icon',
             'creation_date',
             'torrentfile',
             Buttons.cancel_add
         )
+	def is_valid(self):
+		valid = super(AddTemplateForm, self).is_valid()
+		if not valid:
+			return valid
+		if self.cleaned_data['tech'] == 'kvmqm':
+			valid = (self.cleaned_data['kblang'] is not None)
+		return valid
 	
 class EditTemplateForm(TemplateForm):
 	res_id = forms.CharField(max_length=50, widget=forms.HiddenInput)


### PR DESCRIPTION
There is still another bug left (this happens on KVM, not OpenVZ, Repy not tried):

InternalError: backend internal error [None]: Template object can't be deleted because its resource_ptr_id attribute is set to None. ({u'function': u'resource_create', u'kwargs': {}, u'args': [u'template', {u'nlXTP_installed': False, u'torrent_data':[...]', u'icon': u'', u'show_as_common': True, u'restricted': False, u'kblang': u'en-us', u'name': u'debian-7.0_x86', u'subtype': u'linux', u'label': u'Debian 7.0 (x86)', u'tech': u'kvmqm', u'preference': 10, u'creation_date': u'2015-01-26', u'description': u''}], u'entity': u'rpcserver'})