### PR TITLE
dumpmanager doesnt keep all dumps now

### DIFF
--- a/backend/tomato/dumpmanager.py
+++ b/backend/tomato/dumpmanager.py
@@ -13,17 +13,27 @@ from .lib.error import InternalError, UserError # @UnresolvedImport
 class ErrorGroup(models.Model):
 	group_id = models.CharField(max_length=255, primary_key=True)
 	description = models.CharField(max_length=255)
+	removed_dumps = models.IntegerField(default = 0)
 	#dumps: [ErrorDump]
 
 	def update_description(self, description):
 		self.description = description
 		self.save()
+		
+	def shrink(self):
+		c = self.dumps.count()
+		if c > 10:
+			torem = self.dumps.order_by('timestamp')[5:c-5]
+			self.removed_dumps += torem.count()
+			self.dumps.filter(pk__in=list(torem.values_list("id", flat=True))).delete()
+			self.save()
+			
 
 	def info(self):
 		res = {
 			'group_id': self.group_id,
 			'description': self.description,
-			'count': 0,
+			'count': self.removed_dumps,
 			'last_timestamp': 0,
 		    'data_available':False,
             'dump_contents':{}
@@ -99,7 +109,7 @@ class ErrorDump(attributes.Mixin, models.Model):
 	data_available = attributes.attribute("data_available", bool, False)
 	type = attributes.attribute("origin", unicode, "")
 	software_version = attributes.attribute("software_version", dict, "")
-	timestamp = attributes.attribute("timestamp", float, 0)
+	timestamp = models.IntegerField(default=0)
 
 	class Meta:
 		unique_together = (("source", "dump_id"))
@@ -160,6 +170,7 @@ def create_dump(dump, source):
 	d.type = dump['type']
 	d.software_version = dump['software_version']
 	d.save()
+	d.group.shrink()
 	return d
 
 

--- a/backend/tomato/dumpmanager.py
+++ b/backend/tomato/dumpmanager.py
@@ -159,7 +159,7 @@ class ErrorDump(attributes.Mixin, models.Model):
 		self.delete()
 
 
-def create_dump(dump, source):
+def create_dump(dump, source, nosave=False):
 	d = ErrorDump.objects.create(
 		source=source.dump_source_name(),
 		dump_id=dump['dump_id'],
@@ -169,8 +169,8 @@ def create_dump(dump, source):
 	d.description = dump['description']
 	d.type = dump['type']
 	d.software_version = dump['software_version']
-	d.save()
-	d.group.shrink()
+	if not nosave:
+		d.save()
 	return d
 
 
@@ -301,7 +301,7 @@ def find_source_by_name(source_name):
 	return None
 
 
-def insert_dump(dump, source):
+def insert_dump(dump, source, nosave=False):
 	with lock_db:
 		source_name = source.dump_source_name()
 		must_fetch_data = False
@@ -321,7 +321,7 @@ def insert_dump(dump, source):
 				dump['group_id'], source.dump_source_name()))
 
 		#insert the dump.
-		dump_db = create_dump(dump, source)
+		dump_db = create_dump(dump, source, nosave=nosave)
 
 		#if needed, load data
 		if must_fetch_data:
@@ -329,9 +329,16 @@ def insert_dump(dump, source):
 
 
 def update_source(source):
-	new_entries = source.dump_getUpdates()
-	for e in new_entries:
-		insert_dump(e, source)
+	try:
+		new_entries = source.dump_getUpdates()
+		for e in new_entries:
+			insert_dump(e, source, nosave=True)
+	finally:
+		for group in getAll_group():
+			with lock_db:
+				group.shrink()
+				group.dumps.save()
+			
 
 
 def update_all(async=True):

--- a/backend/tomato/migrations/0037_auto__add_field_errorgroup_removed_dumps.py
+++ b/backend/tomato/migrations/0037_auto__add_field_errorgroup_removed_dumps.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'ErrorGroup.removed_dumps'
+        db.add_column('tomato_errorgroup', 'removed_dumps',
+                      self.gf('django.db.models.fields.IntegerField')(default=0),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'ErrorGroup.removed_dumps'
+        db.delete_column('tomato_errorgroup', 'removed_dumps')
+
+
+    models = {
+        'tomato.connection': {
+            'Meta': {'object_name': 'Connection'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'connection1': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.HostConnection']"}),
+            'connection2': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.HostConnection']"}),
+            'connectionElement1': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.HostElement']"}),
+            'connectionElement2': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.HostElement']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'permissions': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Permissions']"}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'topology': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'connections'", 'to': "orm['tomato.Topology']"}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.element': {
+            'Meta': {'object_name': 'Element'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'connection': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'elements'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.Connection']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'children'", 'null': 'True', 'to': "orm['tomato.Element']"}),
+            'permissions': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Permissions']"}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'topology': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'elements'", 'to': "orm['tomato.Topology']"}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '30'})
+        },
+        'tomato.errordump': {
+            'Meta': {'unique_together': "(('source', 'dump_id'),)", 'object_name': 'ErrorDump'},
+            'attrs': ('tomato.lib.db.JSONField', [], {'default': '{}'}),
+            'description': ('tomato.lib.db.JSONField', [], {}),
+            'dump_id': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'dumps'", 'to': "orm['tomato.ErrorGroup']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'tomato.errorgroup': {
+            'Meta': {'object_name': 'ErrorGroup'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'group_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'primary_key': 'True'}),
+            'removed_dumps': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'tomato.external_network': {
+            'Meta': {'object_name': 'External_Network', '_ormbases': ['tomato.Element']},
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'network': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Network']", 'null': 'True'})
+        },
+        'tomato.external_network_endpoint': {
+            'Meta': {'object_name': 'External_Network_Endpoint', '_ormbases': ['tomato.Element']},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'network': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.NetworkInstance']", 'null': 'True'})
+        },
+        'tomato.host': {
+            'Meta': {'ordering': "['site', 'name']", 'object_name': 'Host'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'rpcurl': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'hosts'", 'to': "orm['tomato.Site']"}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.hostconnection': {
+            'Meta': {'unique_together': "(('host', 'num'),)", 'object_name': 'HostConnection'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'host': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'connections'", 'to': "orm['tomato.Host']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num': ('django.db.models.fields.IntegerField', [], {}),
+            'topology_connection': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'host_connections'", 'null': 'True', 'to': "orm['tomato.Connection']"}),
+            'topology_element': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'host_connections'", 'null': 'True', 'to': "orm['tomato.Element']"}),
+            'usageStatistics': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.hostelement': {
+            'Meta': {'unique_together': "(('host', 'num'),)", 'object_name': 'HostElement'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'host': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'elements'", 'to': "orm['tomato.Host']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num': ('django.db.models.fields.IntegerField', [], {}),
+            'topology_connection': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'host_elements'", 'null': 'True', 'to': "orm['tomato.Connection']"}),
+            'topology_element': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'host_elements'", 'null': 'True', 'to': "orm['tomato.Element']"}),
+            'usageStatistics': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.keyvaluepair': {
+            'Meta': {'object_name': 'KeyValuePair'},
+            'attrs': ('tomato.lib.db.JSONField', [], {'default': '{}'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'tomato.kvmqm': {
+            'Meta': {'object_name': 'KVMQM'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'next_sync': ('django.db.models.fields.FloatField', [], {'default': '0', 'db_index': 'True'}),
+            'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Profile']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'rextfv_last_started': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Site']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Template']", 'null': 'True', 'on_delete': 'models.SET_NULL'})
+        },
+        'tomato.kvmqm_interface': {
+            'Meta': {'object_name': 'KVMQM_Interface'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.linkmeasurement': {
+            'Meta': {'unique_together': "(('siteA', 'siteB', 'type', 'end'),)", 'object_name': 'LinkMeasurement'},
+            'begin': ('django.db.models.fields.FloatField', [], {}),
+            'delayAvg': ('django.db.models.fields.FloatField', [], {}),
+            'delayStddev': ('django.db.models.fields.FloatField', [], {}),
+            'end': ('django.db.models.fields.FloatField', [], {'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'loss': ('django.db.models.fields.FloatField', [], {}),
+            'measurements': ('django.db.models.fields.IntegerField', [], {}),
+            'siteA': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['tomato.Site']"}),
+            'siteB': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['tomato.Site']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'})
+        },
+        'tomato.network': {
+            'Meta': {'object_name': 'Network', '_ormbases': ['tomato.Resource']},
+            'kind': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'preference': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'resource_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Resource']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.networkinstance': {
+            'Meta': {'unique_together': "(('host', 'bridge'),)", 'object_name': 'NetworkInstance', 'db_table': "'tomato_network_instance'", '_ormbases': ['tomato.Resource']},
+            'bridge': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'host': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'networks'", 'to': "orm['tomato.Host']"}),
+            'network': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'instances'", 'to': "orm['tomato.Network']"}),
+            'resource_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Resource']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.openvz': {
+            'Meta': {'object_name': 'OpenVZ'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'next_sync': ('django.db.models.fields.FloatField', [], {'default': '0', 'db_index': 'True'}),
+            'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Profile']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'rextfv_last_started': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Site']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Template']", 'null': 'True', 'on_delete': 'models.SET_NULL'})
+        },
+        'tomato.openvz_interface': {
+            'Meta': {'object_name': 'OpenVZ_Interface'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.organization': {
+            'Meta': {'object_name': 'Organization'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.permissionentry': {
+            'Meta': {'unique_together': "(('user', 'set'),)", 'object_name': 'PermissionEntry'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'set': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'entries'", 'to': "orm['tomato.Permissions']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.User']"})
+        },
+        'tomato.permissions': {
+            'Meta': {'object_name': 'Permissions'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'tomato.profile': {
+            'Meta': {'object_name': 'Profile', '_ormbases': ['tomato.Resource']},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'preference': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'resource_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Resource']", 'unique': 'True', 'primary_key': 'True'}),
+            'tech': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'tomato.quota': {
+            'Meta': {'object_name': 'Quota'},
+            'continous_factor': ('django.db.models.fields.FloatField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'monthly': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'on_delete': 'models.PROTECT', 'to': "orm['tomato.Usage']"}),
+            'used': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'on_delete': 'models.PROTECT', 'to': "orm['tomato.Usage']"}),
+            'used_time': ('django.db.models.fields.FloatField', [], {})
+        },
+        'tomato.repy': {
+            'Meta': {'object_name': 'Repy'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'next_sync': ('django.db.models.fields.FloatField', [], {'default': '0', 'db_index': 'True'}),
+            'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Profile']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'rextfv_last_started': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Site']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Template']", 'null': 'True', 'on_delete': 'models.SET_NULL'})
+        },
+        'tomato.repy_interface': {
+            'Meta': {'object_name': 'Repy_Interface'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.resource': {
+            'Meta': {'object_name': 'Resource'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'tomato.site': {
+            'Meta': {'object_name': 'Site'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'organization': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sites'", 'to': "orm['tomato.Organization']"})
+        },
+        'tomato.template': {
+            'Meta': {'object_name': 'Template', '_ormbases': ['tomato.Resource']},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'preference': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'resource_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Resource']", 'unique': 'True', 'primary_key': 'True'}),
+            'tech': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'tomato.templateonhost': {
+            'Meta': {'unique_together': "[('host', 'template')]", 'object_name': 'TemplateOnHost'},
+            'date': ('django.db.models.fields.FloatField', [], {}),
+            'host': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'templates'", 'to': "orm['tomato.Host']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ready': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'hosts'", 'to': "orm['tomato.Template']"})
+        },
+        'tomato.tinc_endpoint': {
+            'Meta': {'object_name': 'Tinc_Endpoint', '_ormbases': ['tomato.Element']},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.tinc_vpn': {
+            'Meta': {'object_name': 'Tinc_VPN', '_ormbases': ['tomato.Element']},
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.topology': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'Topology'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'permissions': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Permissions']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Site']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'timeout': ('django.db.models.fields.FloatField', [], {}),
+            'timeout_step': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.udp_endpoint': {
+            'Meta': {'object_name': 'UDP_Endpoint', '_ormbases': ['tomato.Element']},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.usage': {
+            'Meta': {'object_name': 'Usage'},
+            'cputime': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'diskspace': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'memory': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'traffic': ('django.db.models.fields.FloatField', [], {'default': '0.0'})
+        },
+        'tomato.usagerecord': {
+            'Meta': {'unique_together': "(('statistics', 'type', 'end'),)", 'object_name': 'UsageRecord'},
+            'begin': ('django.db.models.fields.FloatField', [], {}),
+            'end': ('django.db.models.fields.FloatField', [], {'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'measurements': ('django.db.models.fields.IntegerField', [], {}),
+            'statistics': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'records'", 'to': "orm['tomato.UsageStatistics']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            'usage': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'on_delete': 'models.PROTECT', 'to': "orm['tomato.Usage']"})
+        },
+        'tomato.usagestatistics': {
+            'Meta': {'object_name': 'UsageStatistics'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'tomato.user': {
+            'Meta': {'ordering': "['name', 'origin']", 'unique_together': "(('name', 'origin'),)", 'object_name': 'User'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_login': ('django.db.models.fields.FloatField', [], {'default': '1422377239.26211'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'organization': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'users'", 'to': "orm['tomato.Organization']"}),
+            'origin': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '250', 'null': 'True'}),
+            'password_time': ('django.db.models.fields.FloatField', [], {'null': 'True'}),
+            'quota': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'on_delete': 'models.PROTECT', 'to': "orm['tomato.Quota']"}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'on_delete': 'models.PROTECT', 'to': "orm['tomato.UsageStatistics']"})
+        }
+    }
+
+    complete_apps = ['tomato']

--- a/backend/tomato/migrations/0038_auto__add_field_errordump_timestamp.py
+++ b/backend/tomato/migrations/0038_auto__add_field_errordump_timestamp.py
@@ -1,0 +1,305 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'ErrorDump.timestamp'
+        db.add_column('tomato_errordump', 'timestamp',
+                      self.gf('django.db.models.fields.IntegerField')(default=0),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'ErrorDump.timestamp'
+        db.delete_column('tomato_errordump', 'timestamp')
+
+
+    models = {
+        'tomato.connection': {
+            'Meta': {'object_name': 'Connection'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'connection1': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.HostConnection']"}),
+            'connection2': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.HostConnection']"}),
+            'connectionElement1': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.HostElement']"}),
+            'connectionElement2': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.HostElement']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'permissions': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Permissions']"}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'topology': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'connections'", 'to': "orm['tomato.Topology']"}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.element': {
+            'Meta': {'object_name': 'Element'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'connection': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'elements'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.Connection']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'children'", 'null': 'True', 'to': "orm['tomato.Element']"}),
+            'permissions': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Permissions']"}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'topology': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'elements'", 'to': "orm['tomato.Topology']"}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '30'})
+        },
+        'tomato.errordump': {
+            'Meta': {'unique_together': "(('source', 'dump_id'),)", 'object_name': 'ErrorDump'},
+            'attrs': ('tomato.lib.db.JSONField', [], {'default': '{}'}),
+            'description': ('tomato.lib.db.JSONField', [], {}),
+            'dump_id': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'dumps'", 'to': "orm['tomato.ErrorGroup']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'timestamp': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'tomato.errorgroup': {
+            'Meta': {'object_name': 'ErrorGroup'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'group_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'primary_key': 'True'}),
+            'removed_dumps': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'tomato.external_network': {
+            'Meta': {'object_name': 'External_Network', '_ormbases': ['tomato.Element']},
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'network': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Network']", 'null': 'True'})
+        },
+        'tomato.external_network_endpoint': {
+            'Meta': {'object_name': 'External_Network_Endpoint', '_ormbases': ['tomato.Element']},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'network': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.NetworkInstance']", 'null': 'True'})
+        },
+        'tomato.host': {
+            'Meta': {'ordering': "['site', 'name']", 'object_name': 'Host'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'rpcurl': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'hosts'", 'to': "orm['tomato.Site']"}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.hostconnection': {
+            'Meta': {'unique_together': "(('host', 'num'),)", 'object_name': 'HostConnection'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'host': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'connections'", 'to': "orm['tomato.Host']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num': ('django.db.models.fields.IntegerField', [], {}),
+            'topology_connection': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'host_connections'", 'null': 'True', 'to': "orm['tomato.Connection']"}),
+            'topology_element': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'host_connections'", 'null': 'True', 'to': "orm['tomato.Element']"}),
+            'usageStatistics': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.hostelement': {
+            'Meta': {'unique_together': "(('host', 'num'),)", 'object_name': 'HostElement'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'host': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'elements'", 'to': "orm['tomato.Host']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num': ('django.db.models.fields.IntegerField', [], {}),
+            'topology_connection': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'host_elements'", 'null': 'True', 'to': "orm['tomato.Connection']"}),
+            'topology_element': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'host_elements'", 'null': 'True', 'to': "orm['tomato.Element']"}),
+            'usageStatistics': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.keyvaluepair': {
+            'Meta': {'object_name': 'KeyValuePair'},
+            'attrs': ('tomato.lib.db.JSONField', [], {'default': '{}'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'tomato.kvmqm': {
+            'Meta': {'object_name': 'KVMQM'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'next_sync': ('django.db.models.fields.FloatField', [], {'default': '0', 'db_index': 'True'}),
+            'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Profile']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'rextfv_last_started': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Site']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Template']", 'null': 'True', 'on_delete': 'models.SET_NULL'})
+        },
+        'tomato.kvmqm_interface': {
+            'Meta': {'object_name': 'KVMQM_Interface'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.linkmeasurement': {
+            'Meta': {'unique_together': "(('siteA', 'siteB', 'type', 'end'),)", 'object_name': 'LinkMeasurement'},
+            'begin': ('django.db.models.fields.FloatField', [], {}),
+            'delayAvg': ('django.db.models.fields.FloatField', [], {}),
+            'delayStddev': ('django.db.models.fields.FloatField', [], {}),
+            'end': ('django.db.models.fields.FloatField', [], {'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'loss': ('django.db.models.fields.FloatField', [], {}),
+            'measurements': ('django.db.models.fields.IntegerField', [], {}),
+            'siteA': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['tomato.Site']"}),
+            'siteB': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['tomato.Site']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'})
+        },
+        'tomato.network': {
+            'Meta': {'object_name': 'Network', '_ormbases': ['tomato.Resource']},
+            'kind': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'preference': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'resource_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Resource']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.networkinstance': {
+            'Meta': {'unique_together': "(('host', 'bridge'),)", 'object_name': 'NetworkInstance', 'db_table': "'tomato_network_instance'", '_ormbases': ['tomato.Resource']},
+            'bridge': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'host': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'networks'", 'to': "orm['tomato.Host']"}),
+            'network': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'instances'", 'to': "orm['tomato.Network']"}),
+            'resource_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Resource']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.openvz': {
+            'Meta': {'object_name': 'OpenVZ'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'next_sync': ('django.db.models.fields.FloatField', [], {'default': '0', 'db_index': 'True'}),
+            'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Profile']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'rextfv_last_started': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Site']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Template']", 'null': 'True', 'on_delete': 'models.SET_NULL'})
+        },
+        'tomato.openvz_interface': {
+            'Meta': {'object_name': 'OpenVZ_Interface'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.organization': {
+            'Meta': {'object_name': 'Organization'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.permissionentry': {
+            'Meta': {'unique_together': "(('user', 'set'),)", 'object_name': 'PermissionEntry'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'set': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'entries'", 'to': "orm['tomato.Permissions']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.User']"})
+        },
+        'tomato.permissions': {
+            'Meta': {'object_name': 'Permissions'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'tomato.profile': {
+            'Meta': {'object_name': 'Profile', '_ormbases': ['tomato.Resource']},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'preference': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'resource_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Resource']", 'unique': 'True', 'primary_key': 'True'}),
+            'tech': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'tomato.quota': {
+            'Meta': {'object_name': 'Quota'},
+            'continous_factor': ('django.db.models.fields.FloatField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'monthly': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'on_delete': 'models.PROTECT', 'to': "orm['tomato.Usage']"}),
+            'used': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'on_delete': 'models.PROTECT', 'to': "orm['tomato.Usage']"}),
+            'used_time': ('django.db.models.fields.FloatField', [], {})
+        },
+        'tomato.repy': {
+            'Meta': {'object_name': 'Repy'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'}),
+            'next_sync': ('django.db.models.fields.FloatField', [], {'default': '0', 'db_index': 'True'}),
+            'profile': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Profile']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'rextfv_last_started': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Site']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Template']", 'null': 'True', 'on_delete': 'models.SET_NULL'})
+        },
+        'tomato.repy_interface': {
+            'Meta': {'object_name': 'Repy_Interface'},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.resource': {
+            'Meta': {'object_name': 'Resource'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'tomato.site': {
+            'Meta': {'object_name': 'Site'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'organization': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sites'", 'to': "orm['tomato.Organization']"})
+        },
+        'tomato.template': {
+            'Meta': {'object_name': 'Template', '_ormbases': ['tomato.Resource']},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'preference': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'resource_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Resource']", 'unique': 'True', 'primary_key': 'True'}),
+            'tech': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'tomato.templateonhost': {
+            'Meta': {'unique_together': "[('host', 'template')]", 'object_name': 'TemplateOnHost'},
+            'date': ('django.db.models.fields.FloatField', [], {}),
+            'host': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'templates'", 'to': "orm['tomato.Host']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ready': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'hosts'", 'to': "orm['tomato.Template']"})
+        },
+        'tomato.tinc_endpoint': {
+            'Meta': {'object_name': 'Tinc_Endpoint', '_ormbases': ['tomato.Element']},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.tinc_vpn': {
+            'Meta': {'object_name': 'Tinc_VPN', '_ormbases': ['tomato.Element']},
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.topology': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'Topology'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'permissions': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Permissions']"}),
+            'site': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.Site']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'timeout': ('django.db.models.fields.FloatField', [], {}),
+            'timeout_step': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['tomato.UsageStatistics']"})
+        },
+        'tomato.udp_endpoint': {
+            'Meta': {'object_name': 'UDP_Endpoint', '_ormbases': ['tomato.Element']},
+            'element': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['tomato.HostElement']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'element_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['tomato.Element']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'tomato.usage': {
+            'Meta': {'object_name': 'Usage'},
+            'cputime': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'diskspace': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'memory': ('django.db.models.fields.FloatField', [], {'default': '0.0'}),
+            'traffic': ('django.db.models.fields.FloatField', [], {'default': '0.0'})
+        },
+        'tomato.usagerecord': {
+            'Meta': {'unique_together': "(('statistics', 'type', 'end'),)", 'object_name': 'UsageRecord'},
+            'begin': ('django.db.models.fields.FloatField', [], {}),
+            'end': ('django.db.models.fields.FloatField', [], {'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'measurements': ('django.db.models.fields.IntegerField', [], {}),
+            'statistics': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'records'", 'to': "orm['tomato.UsageStatistics']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            'usage': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'on_delete': 'models.PROTECT', 'to': "orm['tomato.Usage']"})
+        },
+        'tomato.usagestatistics': {
+            'Meta': {'object_name': 'UsageStatistics'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'tomato.user': {
+            'Meta': {'ordering': "['name', 'origin']", 'unique_together': "(('name', 'origin'),)", 'object_name': 'User'},
+            'attrs': ('tomato.lib.db.JSONField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_login': ('django.db.models.fields.FloatField', [], {'default': '1422377932.883013'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'organization': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'users'", 'to': "orm['tomato.Organization']"}),
+            'origin': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '250', 'null': 'True'}),
+            'password_time': ('django.db.models.fields.FloatField', [], {'null': 'True'}),
+            'quota': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'on_delete': 'models.PROTECT', 'to': "orm['tomato.Quota']"}),
+            'totalUsage': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'+'", 'unique': 'True', 'on_delete': 'models.PROTECT', 'to': "orm['tomato.UsageStatistics']"})
+        }
+    }
+
+    complete_apps = ['tomato']


### PR DESCRIPTION
It keeps the first and last 5 dumps of a group, and counts how many it has deleted.
The second migration in this pull request will reset all dump timestamps.