### PR TITLE
Reduced server load caused by rextfv_status_updater

### DIFF
--- a/web/tomato/js/editor.js
+++ b/web/tomato/js/editor.js
@@ -4188,8 +4188,6 @@ var RexTFV_status_updater = Class.extend({
         elExists = true;
         mustRemove = false;
 
-        console.log(entry.element);
-
         if (entry.element in editor.topology.elements) { //element exists
             editor.topology.elements[entry.element].update(undefined, undefined, true) //hide errors.
         } else {
@@ -4209,7 +4207,6 @@ var RexTFV_status_updater = Class.extend({
 	},
 	updateSome: function(t) { //this should be called by a timer. Takes RexTFV_status_updater as argument.
 		                      //update only the first five elements of the array. This boundary is to avoid server overload.
-		toRemove = [];
 		var count = 5;
         if (t.elements.length < count) count = t.elements.length; //do not update elements twice.
 		while (count-- > 0) t.updateFirst(t);

--- a/web/tomato/js/editor.js
+++ b/web/tomato/js/editor.js
@@ -4183,6 +4183,37 @@ var RexTFV_status_updater = Class.extend({
 		this.options = options;
 		this.elements = [];
 	},
+	updateFirst: function(t) { //Takes RexTFV_status_updater as argument.
+	    entry = t.elements.shift();
+        elExists = true;
+        mustRemove = false;
+
+        console.log(entry.element);
+
+        if (entry.element in editor.topology.elements) { //element exists
+            editor.topology.elements[entry.element].update(undefined, undefined, true) //hide errors.
+        } else {
+            elExists = false;
+        }
+
+        if (elExists &&
+            editor.topology.elements[entry.element].rextfvStatusSupport() &&
+			editor.topology.elements[entry.element].data.attrs.rextfv_run_status.running) {
+			    entry.tries = 1;
+		} else {
+    		entry.tries--;
+    		mustRemove = (entry.tries < 0)
+		}
+
+		if (!mustRemove) t.elements.push(entry)
+	},
+	updateSome: function(t) { //this should be called by a timer. Takes RexTFV_status_updater as argument.
+		                      //update only the first five elements of the array. This boundary is to avoid server overload.
+		toRemove = [];
+		var count = 5;
+        if (t.elements.length < count) count = t.elements.length; //do not update elements twice.
+		while (count-- > 0) t.updateFirst(t);
+	},
 	updateAll: function(t) { //this should be called by a timer. Takes RexTFV_status_updater as argument.
 		toRemove = [];
 		//iterate through all entries, update them, and then update their retry-count according to the refreshed data.
@@ -4315,7 +4346,7 @@ var Editor = Class.extend({
 			}
 		});
 
-		setInterval(function(){t.rextfv_status_updater.updateAll(t.rextfv_status_updater)}, 1200);
+		setInterval(function(){t.rextfv_status_updater.updateSome(t.rextfv_status_updater)}, 1200);
 	},
 	triggerEvent: function(event) {
 		log(event);


### PR DESCRIPTION
rextfv_status_updater now updates only a maximum of five elements per second.
This is especially important when loading the editor or performing actions on the whole topology, if the topology is big.