### PR TITLE
Fixed a little style bug in the 'new topology' window

### DIFF
--- a/web/tomato/js/editor/workspace.js
+++ b/web/tomato/js/editor/workspace.js
@@ -670,7 +670,6 @@ var Topology = Class.extend({
 		dialog = new AttributeWindow({
 			title: "New Topology",
 			width: 500,
-			height: 500,
 			closable: false,
 			buttons: [
 						{ 


### PR DESCRIPTION
I was annoyed by the wrong placed line in Firefox. So i fixed it. Tested in Chrome and Firefox.