### PR TITLE
centralized error handling

### DIFF
--- a/backend_api/tomato/__init__.py
+++ b/backend_api/tomato/__init__.py
@@ -46,9 +46,6 @@ def login(credentials, sslCert):
 	return user_info or not credentials
 
 from lib import logging
-def handleError():
-	logging.logException()
-	dump.dumpException()
 
 from lib import tasks #@UnresolvedImport
 scheduler = tasks.TaskScheduler(maxLateTime=30.0, minWorkers=5, maxWorkers=settings.settings.get_tasks_settings()[settings.Config.TASKS_MAX_WORKERS])

--- a/backend_api/tomato/lib/exceptionhandling.py
+++ b/backend_api/tomato/lib/exceptionhandling.py
@@ -1,0 +1,1 @@
+../../../shared/lib/exceptionhandling.py

--- a/backend_api/tomato/rpcserver.py
+++ b/backend_api/tomato/rpcserver.py
@@ -20,7 +20,7 @@
 import sys
 
 from . import api, login, getCurrentUserInfo
-from .lib import util, rpc, logging #@UnresolvedImport
+from .lib import util, rpc, logging, exceptionhandling  #@UnresolvedImport
 from .lib.error import Error, UserError, InternalError
 from lib.settings import settings
 
@@ -33,8 +33,7 @@ def handleError(error, function, args, kwargs):
 			error = UserError.wrap(error, data={"function": function.__name__, "args": args, "kwargs": kwargs})
 		else:
 			error = InternalError.wrap(error, data={"function": function.__name__, "args": args, "kwargs": kwargs})
-	logging.logException()
-	error.dump()
+	exceptionhandling.writedown_current_exception(exc=error)
 	return error
 
 def afterCall(*args, **kwargs):

--- a/backend_core/tomato/__init__.py
+++ b/backend_core/tomato/__init__.py
@@ -39,9 +39,6 @@ database_connnection = connect(database_settings['database'], host=database_sett
 database_obj = getattr(database_connnection, database_settings['database'])
 
 from lib import logging
-def handleError():
-	logging.logException()
-	dump.dumpException()
 
 from lib import tasks #@UnresolvedImport
 scheduler = tasks.TaskScheduler(maxLateTime=30.0, minWorkers=5, maxWorkers=settings.settings.get_tasks_settings()[settings.Config.TASKS_MAX_WORKERS])

--- a/backend_core/tomato/lib/exceptionhandling.py
+++ b/backend_core/tomato/lib/exceptionhandling.py
@@ -1,0 +1,1 @@
+../../../shared/lib/exceptionhandling.py

--- a/backend_core/tomato/rpcserver.py
+++ b/backend_core/tomato/rpcserver.py
@@ -20,14 +20,12 @@
 import sys
 
 from . import api
-from .lib import util, sslrpc2, logging #@UnresolvedImport
+from .lib import util, sslrpc2, logging, exceptionhandling  #@UnresolvedImport
 from .lib.error import Error, UserError, InternalError
 
 from lib.settings import settings
 
 import ssl
-
-import traceback
 
 def logCall(function, args, kwargs):
 	logging.log(category="api", method=function.__name__, args=args, kwargs=kwargs)
@@ -38,9 +36,7 @@ def handleError(error, function, args, kwargs):
 			error = UserError.wrap(error, data={"function": function.__name__, "args": args, "kwargs": kwargs})
 		else:
 			error = InternalError.wrap(error, data={"function": function.__name__, "args": args, "kwargs": kwargs})
-	traceback.print_exc()
-	logging.logException()
-	error.dump()
+	exceptionhandling.writedown_current_exception(exc=error)
 	return error
 
 def runServer(server):

--- a/backend_debug/tomato/__init__.py
+++ b/backend_debug/tomato/__init__.py
@@ -33,9 +33,6 @@ database_connection = connect(settings.settings.get_db_settings()['database'], h
 database_obj = getattr(database_connection, settings.settings.get_db_settings()['database'])
 
 from .lib import logging
-def handleError():
-	logging.logException()
-	dump.dumpException()
 
 from .lib import tasks #@UnresolvedImport
 scheduler = tasks.TaskScheduler(maxLateTime=30.0, minWorkers=5, maxWorkers=settings.settings.get_tasks_settings()['max-workers'])

--- a/backend_debug/tomato/lib/exceptionhandling.py
+++ b/backend_debug/tomato/lib/exceptionhandling.py
@@ -1,0 +1,1 @@
+../../../shared/lib/exceptionhandling.py

--- a/backend_debug/tomato/rpcserver.py
+++ b/backend_debug/tomato/rpcserver.py
@@ -20,14 +20,12 @@
 import sys
 
 from . import api
-from .lib import util, sslrpc2, logging #@UnresolvedImport
+from .lib import util, sslrpc2, logging, exceptionhandling  #@UnresolvedImport
 from .lib.error import Error, UserError, InternalError
 
 from lib.settings import settings
 
 import ssl
-
-import traceback
 
 def logCall(function, args, kwargs):
 	logging.log(category="api", method=function.__name__, args=args, kwargs=kwargs)
@@ -38,9 +36,7 @@ def handleError(error, function, args, kwargs):
 			error = UserError.wrap(error, data={"function": function.__name__, "args": args, "kwargs": kwargs})
 		else:
 			error = InternalError.wrap(error, data={"function": function.__name__, "args": args, "kwargs": kwargs})
-	traceback.print_exc()
-	logging.logException()
-	error.dump()
+	exceptionhandling.writedown_current_exception(exc=error)
 	return error
 
 def runServer(server):

--- a/backend_users/tomato/__init__.py
+++ b/backend_users/tomato/__init__.py
@@ -33,9 +33,6 @@ database_connection = connect(settings.settings.get_db_settings()['database'], h
 database_obj = getattr(database_connection, settings.settings.get_db_settings()['database'])
 
 from .lib import logging
-def handleError():
-	logging.logException()
-	dump.dumpException()
 
 from .lib import tasks #@UnresolvedImport
 scheduler = tasks.TaskScheduler(maxLateTime=30.0, minWorkers=5, maxWorkers=settings.settings.get_tasks_settings()['max-workers'])

--- a/backend_users/tomato/lib/exceptionhandling.py
+++ b/backend_users/tomato/lib/exceptionhandling.py
@@ -1,0 +1,1 @@
+../../../shared/lib/exceptionhandling.py

--- a/backend_users/tomato/lib/mail.py
+++ b/backend_users/tomato/lib/mail.py
@@ -3,6 +3,7 @@ from email.mime.text import MIMEText
 from email.header import Header
 from .error import Error, ErrorType
 from settings import settings, Config
+from .exceptionhandling import on_error_continue
 
 @ErrorType
 class MailError(Error):
@@ -13,6 +14,9 @@ class MailError(Error):
 	SUBJECT_MISSING = "subject missing"
 	MESSAGE_MISSING = "message missing"
 
+# this is a problem to be solved by admins or debuggers: don't disturb the rest of the code with non-working e-mail stuff.
+# email notifications are not vital to the functionality of the current call, since there is also a notification.
+@on_error_continue(errorcls_func=lambda e: MailError)
 def send(to_realname, to_addr, subject, message, from_realname=None, from_addr=None):
 	MailError.check(to_realname and to_addr, MailError.RECEIVER_MISSING, "E-Mail receiver is missing", todump=False)
 	MailError.check(subject, MailError.SUBJECT_MISSING, "E-mail subject is missing", todump=True)
@@ -20,17 +24,11 @@ def send(to_realname, to_addr, subject, message, from_realname=None, from_addr=N
 
 	mail_settings = settings.get_email_settings(Config.EMAIL_NOTIFICATION)
 
-	try:
-		msg = MIMEText(mail_settings['body'] % {'realname': to_realname, 'message': message}, 'plain', 'utf-8')
-		msg['Subject'] = Header(mail_settings['subject'] % {'subject': subject}, 'utf-8')
-		msg['From'] = "%s <%s>" %(Header(from_realname, 'utf-8'), from_addr) if from_realname and from_addr else mail_settings['from']
-		msg['To'] = "%s <%s>" % (Header(to_realname, 'utf-8'), to_addr)
+	msg = MIMEText(mail_settings['body'] % {'realname': to_realname, 'message': message}, 'plain', 'utf-8')
+	msg['Subject'] = Header(mail_settings['subject'] % {'subject': subject}, 'utf-8')
+	msg['From'] = "%s <%s>" %(Header(from_realname, 'utf-8'), from_addr) if from_realname and from_addr else mail_settings['from']
+	msg['To'] = "%s <%s>" % (Header(to_realname, 'utf-8'), to_addr)
 
-		s = smtplib.SMTP(mail_settings['smtp-server'])
-		s.sendmail(from_addr or mail_settings['from'], to_addr, msg.as_string())
-		s.quit()
-	except:
-		from .dump import dumpException
-		dumpException()
-		# this is a problem to be solved by admins or debuggers: don't disturb the rest of the code with non-working e-mail stuff.
-		# email notifications are not vital to the functionality of the current call, since there is also a notification.
+	s = smtplib.SMTP(mail_settings['smtp-server'])
+	s.sendmail(from_addr or mail_settings['from'], to_addr, msg.as_string())
+	s.quit()

--- a/backend_users/tomato/rpcserver.py
+++ b/backend_users/tomato/rpcserver.py
@@ -20,14 +20,12 @@
 import sys
 
 from . import api
-from .lib import util, sslrpc2, logging #@UnresolvedImport
+from .lib import util, sslrpc2, logging, exceptionhandling  #@UnresolvedImport
 from .lib.error import Error, UserError, InternalError
 
 from lib.settings import settings
 
 import ssl
-
-import traceback
 
 def logCall(function, args, kwargs):
 	logging.log(category="api", method=function.__name__, args=args, kwargs=kwargs)
@@ -38,9 +36,7 @@ def handleError(error, function, args, kwargs):
 			error = UserError.wrap(error, data={"function": function.__name__, "args": args, "kwargs": kwargs})
 		else:
 			error = InternalError.wrap(error, data={"function": function.__name__, "args": args, "kwargs": kwargs})
-	traceback.print_exc()
-	logging.logException()
-	error.dump()
+	exceptionhandling.writedown_current_exception(exc=error)
 	return error
 
 def runServer(server):

--- a/shared/lib/decorators.py
+++ b/shared/lib/decorators.py
@@ -127,19 +127,6 @@ def profile(out, appendDate=False):
 	return wrap
 
 
-def handleErrors(handle):
-	def wrap(fn):
-		def call(*args, **kwargs):
-			try:
-				return fn(*args, **kwargs)
-			except Exception, exc:
-				handle(exc)
-		call.__name__ = fn.__name__
-		call.__doc__ = fn.__doc__
-		call.__dict__.update(fn.__dict__)
-		return call
-	return wrap
-
 def xmlRpcSafe(fn):
 	def call(*args, **kwargs):
 		res = fn(*args, **kwargs)

--- a/shared/lib/dump.py
+++ b/shared/lib/dump.py
@@ -367,6 +367,3 @@ def dumpError(error):
 		return save_dump(caller=False, description=description, type="Error", group_id=exception_id, data=data)
 	except:
 		dumpException(originalError=str(error))
-
-import error
-error.dumpError = dumpError

--- a/shared/lib/error.py
+++ b/shared/lib/error.py
@@ -3,11 +3,7 @@ import httplib
 import inspect, traceback
 
 from . import anyjson as json
-
-def dumpError(*args):
-	print "Warning: dump.py is not used."
-	print args
-	print args[0].trace
+import exceptionhandling
 
 MODULE = os.environ.get("TOMATO_MODULE", "unknown")
 TYPES = {}
@@ -105,7 +101,7 @@ class Error(Exception):
 		"""
 		dump this error through the dump manager.
 		"""
-		dumpError(self)
+		exceptionhandling.writedown_current_exception()
 
 	@property
 	def raw(self):

--- a/shared/lib/exceptionhandling.py
+++ b/shared/lib/exceptionhandling.py
@@ -1,0 +1,96 @@
+import logging
+import error
+import traceback
+import sys
+
+
+def wrap_and_handle_current_exception(errorcls_func=None, re_raise=True, log_exception=True, dump_exception=True, print_exception=True):
+	type_, exc, trace = sys.exc_info()
+	if errorcls_func is None:
+		errorcls_func = lambda e: error.InternalError
+	if isinstance(exc, error.Error):
+		if exc.todump:
+			writedown_current_exception(log_exception=log_exception, dump_exception=dump_exception, print_exception=print_exception, exc=exc)
+		if re_raise:
+			raise
+	else:
+		newexc = errorcls_func(exc).wrap(exc)
+		writedown_current_exception(log_exception=log_exception, dump_exception=dump_exception and newexc.todump,
+		                            print_exception=print_exception, exc=exc)
+		if re_raise:
+			newexc.todump = False
+			raise newexc.__class__, newexc, trace
+
+def writedown_current_exception(log_exception=True, dump_exception=True, print_exception=True, exc=None):
+	if exc is None:
+		_, exc, _ = sys.exc_info()
+
+	if isinstance(exc, error.Error):
+		if not exc.todump:
+			return
+
+	if log_exception:
+		logging.logException()
+	if dump_exception:
+		import dump
+		dump.dumpException()
+	if print_exception:
+		traceback.print_exc()
+
+	if isinstance(exc, error.Error):
+		exc.todump = False
+
+
+def wrap_errors(errorcls_func=None, log_exception=True, dump_exception=True, print_exception=True):
+	"""
+	wrapper that wraps exceptions to errors, and manages logging, dumping and printing
+	makes sure that errors are only handled once.
+	:param errorcls_func: Function that takes the exception, and returns a sublclass of Error.
+												Usually, this has to decide whether this is an InternalError or UserError.
+												Note that the chosen error class may disable dumping, even though it is set to true.
+												This function will not be used when handling subclasses of Error
+												By default, all Exceptions will be treated as InternalError
+	:param log_exception: whether or not this exception will be logged (default: True)
+	:param dump_exception: whether or not this exception will be dumped (default: True)
+	:param print_exception: whether or not this exception will be printed to the console (default: True)
+	:return:
+	"""
+	def w(func):
+		def func_wrapper(*args, **kwargs):
+			try:
+				return func(*args, **kwargs)
+			except:
+				wrap_and_handle_current_exception(errorcls_func, re_raise=True, log_exception=log_exception, dump_exception=dump_exception, print_exception=print_exception)
+		func_wrapper.__name__ = func.__name__
+		func_wrapper.__doc__ = func.__doc__
+		func_wrapper.__module__ = func.__module__
+		return func_wrapper
+	return w
+
+
+def on_error_continue(errorcls_func=None, log_exception=True, dump_exception=True, print_exception=True):
+	"""
+	Similar to wrap_errors, but does not raise them after handling.
+	If an error occurs, the decorated function returns None.
+	:param errorcls_func: Function that takes the exception, and returns a sublclass of Error.
+												Usually, this has to decide whether this is an InternalError or UserError.
+												Note that the chosen error class may disable dumping, even though it is set to true.
+												This function will not be used when handling subclasses of Error
+												By default, all Exceptions will be treated as InternalError
+	:param log_exception: whether or not this exception will be logged (default: True)
+	:param dump_exception: whether or not this exception will be dumped (default: True)
+	:param print_exception: whether or not this exception will be printed to the console (default: True)
+	:return:
+	"""
+	def w(func):
+		def func_wrapper(*args, **kwargs):
+			try:
+				return func(*args, **kwargs)
+			except:
+				wrap_and_handle_current_exception(errorcls_func, re_raise=False, log_exception=log_exception, dump_exception=dump_exception, print_exception=print_exception)
+				return None
+		func_wrapper.__name__ = func.__name__
+		func_wrapper.__doc__ = func.__doc__
+		func_wrapper.__module__ = func.__module__
+		return func_wrapper
+	return w

--- a/web/tomato/lib/exceptionhandling.py
+++ b/web/tomato/lib/exceptionhandling.py
@@ -1,0 +1,1 @@
+../../../shared/lib/exceptionhandling.py


### PR DESCRIPTION
Closes #985 (except for startup errors  -> new issue)
After merging, we have to:
* annotate functions with the new decorators (-> new issue with a checkbox list with one entry per service)
* check that all functions use the new method (-> new issue with a checkbox list woth one entry per service)