### PR TITLE
fixed 30day-active-users counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Entries should be sorted by component and status with important entries and entr
 
 ### UNRELEASED (RUNNING ON SERVERS)
 
+- [backend_users, fixed] Logins are now saved again for display in 30-day active users count
 - [backend_api, fixed] Fixed __statistics__ API call
 - [backend_api, fixed] Fixed authorization for download actions on elements
 - [backend_api, changed] Removed configuration info calls

--- a/backend_users/tomato/api/auth.py
+++ b/backend_users/tomato/api/auth.py
@@ -1,5 +1,10 @@
 from _shared import _getUser
 
-def user_check_password(name, password):
+def user_check_password(name, password, notify_activity=True):
 	user = _getUser(name)
-	return user.checkPassword(password)
+	if user.checkPassword(password):
+		if notify_activity:
+			user.register_activity()
+		return True
+	else:
+		return False

--- a/backend_users/tomato/user.py
+++ b/backend_users/tomato/user.py
@@ -231,6 +231,10 @@ class User(Entity, BaseDocument):
 		notif.read = read
 		self.save()
 
+	def register_activity(self):
+		self.lastLogin = time.time()
+		self.save()
+
 	def clean_up_notifications(self):
 		border_read = time.time() - 60*60*24*30  # fixme: should be configurable
 		border_unread = time.time() - 60*60*24*180  # fixme: should be configurable


### PR DESCRIPTION
After the split we removed code that registered user activity. This lead to the problem that no new user activity was counted, and after one month there would have been no 30-day active user.
Now, on every password check, activity is counted, if not specificly called as non-counting.