### PR TITLE
Permission fix

### DIFF
--- a/backend_api/tomato/api/topology.py
+++ b/backend_api/tomato/api/topology.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 from api_helpers import getCurrentUserInfo, getCurrentUserName
+from ..lib.topology_role import Role
 from ..lib.remote_info import get_topology_info, get_topology_list, TopologyInfo,get_organization_info
 from ..lib.service import get_backend_core_proxy,get_backend_users_proxy
 from ..lib.error import UserError
@@ -221,6 +222,9 @@ def topology_set_permission(id, user, role): #@ReservedAssignment
 	  The name of the role for this user. If the user already has a role,
 	  if will be changed.
 	"""
+	if role is None:
+		role = Role.null
+
 	topl = get_topology_info(id)
 	UserError.check(topl.exists(), code=UserError.ENTITY_DOES_NOT_EXIST, message="Topology with that name does not exist")
 	UserError.check(get_backend_users_proxy().user_exists(user), code=UserError.ENTITY_DOES_NOT_EXIST, message="User with that name does not exist")

--- a/shared/lib/remote_info.py
+++ b/shared/lib/remote_info.py
@@ -453,10 +453,7 @@ class TopologyInfo(ActionObj):
 		return res
 
 	def existsRole(self,role):
-		for r in topology_role.Role.RANKING:
-			if r == role:
-				return True
-		return False
+		return role in topology_role.Role.RANKING
 
 
 

--- a/shared/lib/topology_role.py
+++ b/shared/lib/topology_role.py
@@ -4,7 +4,7 @@ class Role:
 	user = "user" # no destroy/prepare, no topology changes, no permission changes
 	null = "null" # no access at all
 
-	RANKING=[null, user, manager, owner]
+	RANKING = [null, user, manager, owner]
 
 	@staticmethod
 	def max(role_1, role_2):


### PR DESCRIPTION
The API did not accept `role==None`, but only `role=="null"`. however, since the null role and `None` should be equal, the API can now translate that.
The editor only uses `None`, which means that this bugs prevents users from removing other users from topologies.
Also, some code style enhancements