### PR TITLE
better timeout warning

### DIFF
--- a/web/tomato/js/editor/topology.js
+++ b/web/tomato/js/editor/topology.js
@@ -556,8 +556,8 @@ var Topology = Class.extend({
 		var timeout_settings = t.editor.options.timeout_settings;
 		for (var i = 0; i < timeout_settings.options.length; i++) choices[timeout_settings.options[i]] = formatDuration(timeout_settings.options[i]);
 		var timeout_val = t.data.timeout - new Date().getTime()/1000.0;
-		var text = timeout_val > 0 ? ("Your topology will time out in " + formatDuration(timeout_val)) : "Your topology has timed out. You must renew it to use it.";
-		if (timeout_val < timeout_settings.warning) text = '<b style="color:red">' + text + '</b>';
+		var text = timeout_val > 0 ? ("Your topology will time out in <strong>" + formatDuration(timeout_val)) + "</strong>" : "Your topology has timed out. You must renew it to use it.";
+		if (timeout_val < timeout_settings.warning) text = '<p class="alert alert-danger">' + text + '</p>';
 		dialog.addText("<center>"  + text + "</center>");
 		if (may_renew) {
 			// if user is allowed to renew


### PR DESCRIPTION
using bootstrap's <p class="alert alert-danger"> for error messages in forms. currently, only the timeout warning is affected by this.
Closes #1398