### PR TITLE
Backend problems manager

### DIFF
--- a/backend_api/tomato/api/__init__.py
+++ b/backend_api/tomato/api/__init__.py
@@ -26,7 +26,7 @@ from connections import connection_create, connection_info, connection_modify, c
 	connection_action, connection_usage
 
 from debug import debug_stats, debug_services_reachable, debug_run_internal_api_call, debug_run_host_api_call,\
-	debug_execute_task, debug_debug_internal_api_call, ping, debug_throw_error
+	debug_execute_task, debug_debug_internal_api_call, ping, debug_throw_error, debug_services_overview
 
 from dumpmanager import errordump_info, errordump_list, errordumps_force_refresh, errorgroup_favorite,\
 	errorgroup_hide, errorgroup_info, errorgroup_list, errorgroup_modify, errorgroup_remove, errordump_store

--- a/backend_api/tomato/api/__init__.py
+++ b/backend_api/tomato/api/__init__.py
@@ -18,7 +18,7 @@
 from account import account_create, account_info, account_list, account_modify, account_remove, account_usage
 
 from account_notification import account_notifications, account_notification_set_read, account_send_notification,\
-	broadcast_announcement, notifyAdmins
+	broadcast_announcement, notifyAdmins, account_notification_set_all_read
 
 from capabilities import capabilities, capabilities_connection, capabilities_element
 

--- a/backend_api/tomato/api/debug.py
+++ b/backend_api/tomato/api/debug.py
@@ -4,6 +4,8 @@ import traceback, sys
 from api_helpers import getCurrentUserInfo
 from ..lib.debug import run
 from ..lib.settings import Config
+from ..service_status import service_status, problems
+from ..service_status_manager import get_all_stats
 from ..lib.service import is_reachable, is_self, get_tomato_inner_proxy, get_backend_core_proxy
 from ..lib.remote_info import get_host_info
 from ..lib.exceptionhandling import wrap_and_handle_current_exception
@@ -17,18 +19,16 @@ def debug_stats(tomato_module=Config.TOMATO_MODULE_BACKEND_API):
 	if is_self(tomato_module):
 		return {
 			"scheduler": scheduler.info(),
-			"threads": map(traceback.extract_stack, sys._current_frames().values())
+			"threads": map(traceback.extract_stack, sys._current_frames().values()),
+			"system": service_status(),
+			"problems": problems()
 		}
 	else:
 		api = get_tomato_inner_proxy(tomato_module)
 		return api.debug_stats()
 
 def debug_services_overview():
-	res = {}
-	for module in Config.TOMATO_BACKEND_MODULES:
-		res[module] = {
-			'reachable': is_reachable(module)
-		}
+	return get_all_stats()
 
 def debug_services_reachable():
 	res = {module: is_reachable(module) for module in Config.TOMATO_BACKEND_MODULES}

--- a/backend_api/tomato/service_status.py
+++ b/backend_api/tomato/service_status.py
@@ -1,0 +1,1 @@
+../../shared/service_status.py

--- a/backend_api/tomato/service_status_manager.py
+++ b/backend_api/tomato/service_status_manager.py
@@ -1,0 +1,95 @@
+from .lib.settings import Config
+from .lib.error import UserError
+from .lib.userflags import Flags
+from .lib.service import is_reachable, get_tomato_inner_proxy, is_self, get_backend_users_proxy
+from . import scheduler
+from threading import RLock
+
+class ModuleStatus(object):
+	__slots__ = ("tomato_module", "lock",
+	             "last_problems",
+	             "last_reachable")
+
+	def __init__(self, tomato_module):
+		self.tomato_module = tomato_module
+		self.last_problems = set()
+		self.last_reachable = True
+		self.lock = RLock()
+
+	def send_problem_report(self, problem, resolved=False):
+		title = "Backend Problems: %s" % self.tomato_module
+		if resolved:
+			message = "A problem on %s has been resolved: %s" % problem
+		else:
+			message = "A problem on %s has been detected: %s" % problem
+		get_backend_users_proxy().broadcast_message_multifilter(title=title, message=message, ref=None, subject_group="backend failure",
+																			filters = [
+																				(None, Flags.GlobalHostManager),
+																				(None, Flags.GlobalHostContact),
+																				(None, Flags.Debug)
+																			])
+
+	def check(self):
+		with self.lock:
+			if is_reachable(self.tomato_module) or is_self(self.tomato_module):
+				if is_self(self.tomato_module):
+					from . import api
+				else:
+					api = get_tomato_inner_proxy(self.tomato_module)
+					if not self.last_reachable:
+						self.last_reachable = True
+						self.send_problem_report("service unreachable", True)
+				debug_stats = api.debug_stats()
+				new_problems = set(debug_stats.get("problems", ()))
+				for new_problem in (new_problems-self.last_problems):
+					self.send_problem_report(new_problem, False)
+				for resolved_problem in (self.last_problems-new_problems):
+					self.send_problem_report(resolved_problem, True)
+				self.last_problems = new_problems
+			else:
+				if self.last_reachable:
+					self.send_problem_report("service unreachable", False)
+					self.last_reachable = False
+
+	def get_problems(self):
+		res = []
+		with self.lock:
+			self.check()
+			if not self.last_reachable:
+				res.append("service unreachable")
+			res.extend(self.last_problems)
+			return res
+
+	def info(self):
+		with self.lock:
+			self.check()
+			return {
+				'reachable': self.last_reachable,
+				'problems': self.get_problems()
+			}
+
+
+
+
+
+
+modules = {}
+for tomato_module in Config.TOMATO_BACKEND_MODULES:
+	modules[tomato_module] = ModuleStatus(tomato_module)
+def _get_module(tomato_module):
+	"""
+	:param str tomato_module:
+	:return:
+	:rtype: ModuleStatus
+	"""
+	UserError.check(tomato_module in Config.TOMATO_BACKEND_MODULES, code=UserError.INVALID_VALUE, message="no such backend module", data={"tomato_module": tomato_module})
+	return modules[tomato_module]
+
+def get_all_stats():
+	return {tomato_module: _get_module(tomato_module).info() for tomato_module in Config.TOMATO_BACKEND_MODULES}
+
+
+def checkModule(tomato_module):
+	_get_module(tomato_module).check()
+for tomato_module in Config.TOMATO_BACKEND_MODULES:
+	scheduler.scheduleRepeated(5*60, checkModule, tomato_module)

--- a/backend_core/tomato/api/debug.py
+++ b/backend_core/tomato/api/debug.py
@@ -1,4 +1,5 @@
 from .. import scheduler
+from ..service_status import service_status, problems
 from ..lib.debug import run
 from ..lib.error import InternalError
 from ..lib.exceptionhandling import wrap_and_handle_current_exception
@@ -12,7 +13,9 @@ def debug_stats():
 	stats = {
 		"db": database_obj.command("dbstats"),
 		"scheduler": scheduler.info(),
-		"threads": map(traceback.extract_stack, sys._current_frames().values())
+		"threads": map(traceback.extract_stack, sys._current_frames().values()),
+		"system": service_status(),
+		"problems": problems()
 	}
 	stats["db"]["collections"] = {name: database_obj.command("collstats", name) for name in
 	                              database_obj.collection_names()}

--- a/backend_core/tomato/service_status.py
+++ b/backend_core/tomato/service_status.py
@@ -1,0 +1,1 @@
+../../shared/service_status.py

--- a/backend_debug/tomato/api/debug.py
+++ b/backend_debug/tomato/api/debug.py
@@ -1,4 +1,5 @@
 from .. import scheduler
+from ..service_status import service_status, problems
 from ..lib.debug import run
 from ..lib.error import InternalError
 from ..lib.exceptionhandling import wrap_and_handle_current_exception
@@ -12,7 +13,9 @@ def debug_stats():
 	stats = {
 		"db": database_obj.command("dbstats"),
 		"scheduler": scheduler.info(),
-		"threads": map(traceback.extract_stack, sys._current_frames().values())
+		"threads": map(traceback.extract_stack, sys._current_frames().values()),
+		"system": service_status(),
+		"problems": problems()
 	}
 	stats["db"]["collections"] = {name: database_obj.command("collstats", name) for name in
 	                              database_obj.collection_names()}

--- a/backend_debug/tomato/service_status.py
+++ b/backend_debug/tomato/service_status.py
@@ -1,0 +1,1 @@
+../../shared/service_status.py

--- a/backend_users/tomato/api/debug.py
+++ b/backend_users/tomato/api/debug.py
@@ -1,4 +1,5 @@
 from .. import scheduler
+from ..service_status import service_status, problems
 from ..lib.debug import run
 from ..lib.error import InternalError
 from ..lib.exceptionhandling import wrap_and_handle_current_exception
@@ -12,7 +13,9 @@ def debug_stats():
 	stats = {
 		"db": database_obj.command("dbstats"),
 		"scheduler": scheduler.info(),
-		"threads": map(traceback.extract_stack, sys._current_frames().values())
+		"threads": map(traceback.extract_stack, sys._current_frames().values()),
+		"system": service_status(),
+		"problems": problems()
 	}
 	stats["db"]["collections"] = {name: database_obj.command("collstats", name) for name in
 	                              database_obj.collection_names()}

--- a/backend_users/tomato/service_status.py
+++ b/backend_users/tomato/service_status.py
@@ -1,0 +1,1 @@
+../../shared/service_status.py

--- a/docker/build/tomato_service/Dockerfile
+++ b/docker/build/tomato_service/Dockerfile
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install --no-instal
 ADD get-pip.py /tmp/get-pip.py
 RUN python /tmp/get-pip.py; rm /tmp/get-pip.py
   
-RUN pip install mongoengine\>=0.10,\<0.11 pymongo\>=3.0,\<3.1 pyopenssl\<0.16 msgpack-python\<0.5 pyyaml\<4
+RUN pip install mongoengine\>=0.10,\<0.11 pymongo\>=3.0,\<3.1 pyopenssl\<17 msgpack-python\<0.5 pyyaml\<4 psutil
 
 RUN mkdir -p /tmp/snappy; cd /tmp/snappy; \
     wget https://github.com/andrix/python-snappy/archive/ca913c70193441045f7c95ddcf0de419f195d0b6.tar.gz -O - | tar -xzv; \

--- a/docker/build/tomato_service/Dockerfile
+++ b/docker/build/tomato_service/Dockerfile
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install --no-instal
 ADD get-pip.py /tmp/get-pip.py
 RUN python /tmp/get-pip.py; rm /tmp/get-pip.py
   
-RUN pip install mongoengine\>=0.10,\<0.11 pymongo\>=3.0,\<3.1 pyopenssl\<17 msgpack-python\<0.5 pyyaml\<4 psutil
+RUN pip install mongoengine\>=0.10,\<0.11 pymongo\>=3.0,\<3.1 pyopenssl msgpack-python\<0.5 pyyaml\<4 psutil
 
 RUN mkdir -p /tmp/snappy; cd /tmp/snappy; \
     wget https://github.com/andrix/python-snappy/archive/ca913c70193441045f7c95ddcf0de419f195d0b6.tar.gz -O - | tar -xzv; \

--- a/shared/service_status.py
+++ b/shared/service_status.py
@@ -1,0 +1,43 @@
+import os
+import psutil
+from .lib.settings import settings, Config
+from .lib.service import get_backend_debug_proxy
+from . import scheduler
+
+def service_status():
+	# file system
+	fs_stats = os.statvfs("/")
+	fs_bytes_avail = fs_stats.f_frsize*fs_stats.f_bavail
+	fs_bytes_total = fs_stats.f_frsize*fs_stats.f_blocks
+
+	#memory
+	mem_stats = psutil.virtual_memory()
+	mem_avail = mem_stats.available
+	mem_total = mem_stats.total
+
+	return {
+		"filesystem": {
+			"avail": fs_bytes_avail/(1024*1024),
+			"total": fs_bytes_total/(1024*1024)
+		},
+		"memory": {
+			"avail": mem_avail/(1024*1024),
+			"total": mem_total/(1024*1024)
+		}
+	}
+
+
+def problems():
+	res = []
+
+	mem_stats = psutil.virtual_memory()
+	free_mem_percent = float(mem_stats.available) / float(mem_stats.total)
+	if free_mem_percent < 0.06:
+		res.append("memory usage is critical")
+
+	fs_stats = os.statvfs("/")
+	free_fs_percent = float(fs_stats.f_bavail) / float(fs_stats.f_blocks)
+	if free_fs_percent < 0.06:
+		res.append("disk usage is critical")
+
+	return res

--- a/shared/service_status.py
+++ b/shared/service_status.py
@@ -31,7 +31,7 @@ def problems():
 	res = []
 
 	mem_stats = psutil.virtual_memory()
-	free_mem_percent = float(mem_stats.available) / float(mem_stats.total)
+	free_mem_percent = 1-mem_stats.percent
 	if free_mem_percent < 0.06:
 		res.append("memory usage is critical")
 

--- a/web/tomato/debug.py
+++ b/web/tomato/debug.py
@@ -45,11 +45,14 @@ def connection(api, request, id):
 def stats(api, request, tomato_module=None):
 	if tomato_module is None:
 		try:
-			v = api.debug_services_reachable()
+			v = api.debug_services_overview()
 		except:
-			v = {Config.TOMATO_MODULE_BACKEND_API: False}
-		values = [{'module': module, 'reachable': reachable} for module, reachable in v.iteritems()]
-		return render(request, "debug/backend_overview.html", {"reachability_stats": values})
+			v = {Config.TOMATO_MODULE_BACKEND_API: {"reachable": False, "problems": ["service unreachable"]}}
+			for tomato_module in Config.TOMATO_BACKEND_INTERNAL_REACHABLE_MODULES:
+				v[tomato_module] = {"reachable": False, "problems": ["backend_api unreachable"]}
+		for k, v_ in v.iteritems():
+			v_["module"] = k
+		return render(request, "debug/backend_overview.html", {"reachability_stats": v.itervalues()})
 	else:
 		stats = api.debug_stats(tomato_module)
 		return render(request, "debug/stats.html", {'stats': stats, 'tomato_module': tomato_module})

--- a/web/tomato/dumpmanager.py
+++ b/web/tomato/dumpmanager.py
@@ -116,7 +116,7 @@ def group_info(api, request, group_id):
 					s = s[len(pref):]
 					break
 			errordump['source___displayname'] = s
-		if "ref" in errordump["description"]["data"]:
+		if "ref" in errordump["description"].get("data", {}):
 			errordump["ref___link"], errordump["ref___text"] = resolve_reference(api, errordump["description"]["data"]["ref"])
 	errorgroup['dumps'].sort(key=lambda d: d['timestamp'])
 	errorgroup['github_url'] = errorgroup.get('_github_url', False)

--- a/web/tomato/templates/account/notifications.html
+++ b/web/tomato/templates/account/notifications.html
@@ -40,14 +40,15 @@
 			try {
 				var xmlhttp=new XMLHttpRequest();
 				xmlhttp.onreadystatechange = function() {
-				if (xmlhttp.readyState==4) {
-					try {
-						res = JSON.parse(xmlhttp.responseText);
-					} catch(ex) {
-						alert('Failed to mark notifification');
-					}
+					if (xmlhttp.readyState==4) {
+						try {
+							res = JSON.parse(xmlhttp.responseText);
+						} catch(ex) {
+							alert('Failed to mark notifification');
+						}
 
-					location.reload();
+						location.reload();
+					}
 				}
 				xmlhttp.open("GET", url, true);
 				xmlhttp.send();

--- a/web/tomato/templates/debug/backend_overview.html
+++ b/web/tomato/templates/debug/backend_overview.html
@@ -11,7 +11,7 @@
 
 <tr>
     <th>Backend Module</th>
-    <th>known problems</th>
+    <th>Known Problems</th>
     <th>Reachable</th>
 </tr>
 

--- a/web/tomato/templates/debug/backend_overview.html
+++ b/web/tomato/templates/debug/backend_overview.html
@@ -11,12 +11,19 @@
 
 <tr>
     <th>Backend Module</th>
+    <th>known problems</th>
     <th>Reachable</th>
 </tr>
 
 {% for module_result in reachability_stats %}
     <tr>
         <td><a href="{%url "tomato.debug.stats" module_result.module%}">{{module_result.module}}</a></td>
+
+        <td>
+            {% if module_result.problems %}
+                {{module_result.problems}}
+            {% endif %}
+        </td>
 
         {% if module_result.reachable %}
             <td class="stddev_high good_high">Yes</td>

--- a/web/tomato/templates/debug/stats.html
+++ b/web/tomato/templates/debug/stats.html
@@ -12,6 +12,35 @@
 
 <div class="skip-sm"></div>
 
+{% if stats.problems %}
+
+<div class="alert alert-danger">This service is experiencing the following problems:
+	<ul>
+		{% for problem in stats.problems %}
+			<li>{{problem}}</li>
+		{% endfor %}
+	</ul>
+</div>
+
+<div class="skip-sm"></div>
+{% endif %}
+
+{% if stats.system %}
+<h2>System</h2>
+
+<table class="table table-striped">
+	<tr>
+		<th>Memory (available)</th>
+		<th>Diskspace (available)</th>
+	</tr>
+	<tr>
+		<td>{{stats.system.memory.avail}} MiB / {{stats.system.memory.total}} MiB</td>
+		<td>{{stats.system.filesystem.avail}} MiB / {{stats.system.filesystem.total}} MiB</td>
+	</tr>
+</table>
+<div class="skip-sm"></div>
+{% endif %}
+
 {% if stats.db %}
 <h2>Database</h2>
 


### PR DESCRIPTION
backend_api now regularly checks all backend modules for problems. New problems or resolved problems are reported to debug users and global host managers and host contacts.

Currently detected problems:
 * critical memory usage
 * critical disk usage
 * unavailability

I chose backend_api for this because it is the one component that is not reachable from the other components, and thus this is the only way to check backend_api stats without having duplicate code.

Currently, notifications are not resent after some time. Also, the problem status is kept in memory, i.e., all problems are assumed to be non-existent at API startup (resulting in duplicate error notifications and missing resolved-notifications. I don't think that this might be a problem.

Of course, notifications do not work when backend_users is not reachable. I suggested a year ago that we need a persistent message queue for internal communication (at least for some functions); if this is ever implemented we can use this for this notification sending.

This also fixes the following problems:
 * missing bracket in notification set read function in account notification template
 * missing import of account_notification_set_all_read in backend_api API
 * web dumpmanager group info crashes when no "data" in dump