### PR TITLE
Fixes 

### DIFF
--- a/backend_api/tomato/api/account_notification.py
+++ b/backend_api/tomato/api/account_notification.py
@@ -35,7 +35,7 @@ def account_notification_set_all_read(read):
 	"""
 	username = getCurrentUserName()
 	api = get_backend_users_proxy()
-	api.notification_set_all_read(read)
+	api.notification_set_all_read(username, read)
 	get_user_info(username).invalidate_info()
 
 def account_send_notification(name, subject, message, ref=None, from_support=False, subject_group=None):

--- a/backend_api/tomato/api/debug.py
+++ b/backend_api/tomato/api/debug.py
@@ -14,15 +14,22 @@ from ..lib.error import InternalError
 def ping():
 	return True
 
+def _debug_stats_withoutauth():
+	"""
+	debug stats, but without authentication. Only use internally.
+	:return:
+	"""
+	return {
+		"scheduler": scheduler.info(),
+		"threads": map(traceback.extract_stack, sys._current_frames().values()),
+		"system": service_status(),
+		"problems": problems()
+	}
+
 def debug_stats(tomato_module=Config.TOMATO_MODULE_BACKEND_API):
 	getCurrentUserInfo().check_may_view_debugging_info()
 	if is_self(tomato_module):
-		return {
-			"scheduler": scheduler.info(),
-			"threads": map(traceback.extract_stack, sys._current_frames().values()),
-			"system": service_status(),
-			"problems": problems()
-		}
+		return _debug_stats_withoutauth()
 	else:
 		api = get_tomato_inner_proxy(tomato_module)
 		return api.debug_stats()

--- a/backend_api/tomato/service_status_manager.py
+++ b/backend_api/tomato/service_status_manager.py
@@ -33,13 +33,14 @@ class ModuleStatus(object):
 		with self.lock:
 			if is_reachable(self.tomato_module) or is_self(self.tomato_module):
 				if is_self(self.tomato_module):
-					from . import api
+					from .api.debug import _debug_stats_withoutauth
+					debug_stats = _debug_stats_withoutauth()
 				else:
 					api = get_tomato_inner_proxy(self.tomato_module)
 					if not self.last_reachable:
 						self.last_reachable = True
 						self.send_problem_report("service unreachable", True)
-				debug_stats = api.debug_stats()
+					debug_stats = api.debug_stats()
 				new_problems = set(debug_stats.get("problems", ()))
 				for new_problem in (new_problems-self.last_problems):
 					self.send_problem_report(new_problem, False)

--- a/docker/run/config.yaml
+++ b/docker/run/config.yaml
@@ -33,7 +33,7 @@ web-url: http://127.0.0.1:8080
 
 external-urls:
   aup:        http://tomato-lab.org/aup
-  help:       http://github.com/GLab/ToMaTo/wiki
+  help:       http://tomato-lab.org/manuals/user/
   impressum:  http://tomato-lab.org/contact/
   project:    http://tomato-lab.org
   json-feed:  http://www.tomato-lab.org/feed.json

--- a/docker/run/tomato-ctl.py
+++ b/docker/run/tomato-ctl.py
@@ -575,6 +575,7 @@ class Module:
 			flat_list([["-p", "%s:%s" % p] for p in ports]),
 			["-e", "TIMEZONE=%s" % timezone],
 			["-e", "TOMATO_VERSION=%s" % tomato_version],
+			["-e", "TOMATO_MODULE=%s" % module_name],
 			["-e", "SECRET_KEY=%s" % "".join(random.choice(string.digits+string.ascii_letters) for _ in range(32))],
 			["--name", self.container_name],
 			additional_args,

--- a/shared/lib/dump.py
+++ b/shared/lib/dump.py
@@ -397,9 +397,9 @@ def dumpUnknownException(type_, value, trace, **kwargs):
 # function to handle an Error from tomato.lib.error.py
 def dumpError(error):
 	try:
-		if not error.todump:
+		if (not error.todump) or (error.wasdumped):
 			return None
-		error.todump = False
+		error.wasdumped = True
 
 		trace = error.trace
 		data = {

--- a/shared/lib/dump.py
+++ b/shared/lib/dump.py
@@ -411,6 +411,7 @@ def dumpError(error):
 		
 		description = error.raw
 		del description['todump']
+		del description['wasdumped']
 		
 		exception_id = error.group_id()
 		

--- a/shared/lib/error.py
+++ b/shared/lib/error.py
@@ -54,12 +54,13 @@ class Error(Exception):
 	TYPE = "general"
 	UNKNOWN = None
 
-	def __init__(self, code=None, message=None, data=None, type=None, todump=None, module=MODULE, httpcode=None, onscreenmessage=None, frame=None, frame_trace=None, trace=None):
+	def __init__(self, code=None, message=None, data=None, type=None, todump=None, module=MODULE, httpcode=None, onscreenmessage=None, frame=None, frame_trace=None, trace=None, wasdumped=False):
 		self.type = type or self.TYPE
 		self.code = code
 		self.message = message
 		self.data = data or {}
 		self.module = module
+		self.wasdumped = wasdumped
 		if trace is None:
 			self.trace = traceback.extract_stack()
 		else:

--- a/shared/lib/settings.py
+++ b/shared/lib/settings.py
@@ -39,7 +39,7 @@ web-url: http://127.0.0.1:8080
 
 external-urls:
   aup:        http://tomato-lab.org/aup
-  help:       http://github.com/GLab/ToMaTo/wiki
+  help:       http://tomato-lab.org/manuals/user/
   impressum:  http://tomato-lab.org/contact/
   project:    http://tomato-lab.org
   json-feed:  http://www.tomato-lab.org/feed.json

--- a/shared/lib/tasks.py
+++ b/shared/lib/tasks.py
@@ -5,6 +5,8 @@ Created on Jan 24, 2014
 '''
 
 import threading, time, random
+from .error import Error
+from .exceptionhandling import wrap_and_handle_current_exception
 
 MAX_WAIT = 3600.0
 
@@ -45,10 +47,11 @@ class Task(object):
 		try:
 			self.fn(*self.args, **self.kwargs)
 			self.success = True
-		except Exception:
+		except Exception, e:
 			self.success = False
-			import traceback
-			traceback.print_exc()
+			if isinstance(e, Error):
+				e.todump = True
+			wrap_and_handle_current_exception(re_raise=False)
 		self.duration = time.time()-self.last
 		self.last = self.next
 		if self.repeated:

--- a/web/tomato/js/editor/component.js
+++ b/web/tomato/js/editor/component.js
@@ -92,7 +92,7 @@ var Component = Class.extend({
 		
 		var helpTarget = undefined;
 		if ($.inArray(this.data.type,settings.supported_configwindow_help_pages)) {
-			helpTarget = help_baseUrl+"/editor:configwindow_"+this.data.type;
+			helpTarget = this.helpTarget ? this.helpTarget : help_baseUrl;
 		}
 
 		

--- a/web/tomato/js/editor/components/connection.js
+++ b/web/tomato/js/editor/components/connection.js
@@ -6,6 +6,7 @@ var Connection = Component.extend({
 		this._super(topology, data, canvas);
 		this.elements = [];
 		this.segment = -1;
+		this.helpTarget = "http://tomato-lab.org/manuals/user/connection/"
 	},
 	fromElement: function() {
 		return this.elements[0].id < this.elements[1].id ? this.elements[0] : this.elements[1];
@@ -187,7 +188,8 @@ var Connection = Component.extend({
 					t.configWindow.remove();
 					t.configWindow = null;
 				} 
-			}
+			},
+			helpTarget: this.helpTarget
 		}, this);
 		this.configWindow.show();
 		this.triggerEvent({operation: "attribute-dialog"});

--- a/web/tomato/js/editor/components/elements/child_elements/vm_interface_element.js
+++ b/web/tomato/js/editor/components/elements/child_elements/vm_interface_element.js
@@ -1,5 +1,9 @@
 
 var VMInterfaceElement = ChildElement.extend({
+	init: function(topology, data, canvas) {
+		this._super(topology, data, canvas);
+		this.helpTarget = "http://tomato-lab.org/manuals/user/element/device/" + data.type.replace("_interface", "") + "#interface_config";
+	},
 	showUsedAddresses: function() {
 		var t = this;
 		this.update(true, function() {

--- a/web/tomato/js/editor/components/elements/icon_elements/vm_element.js
+++ b/web/tomato/js/editor/components/elements/icon_elements/vm_element.js
@@ -1,6 +1,10 @@
 
 
 var VMElement = IconElement.extend({
+	init: function(topology, data, canvas) {
+		this._super(topology, data, canvas);
+		this.helpTarget = "http://tomato-lab.org/manuals/user/element/device/"+data.type+"#config"
+	},
 	isConnectable: function() {
 		return this._super() && !this.busy;
 	},

--- a/web/tomato/js/editor/windows/connection_attribute_window.js
+++ b/web/tomato/js/editor/windows/connection_attribute_window.js
@@ -1,6 +1,5 @@
 var ConnectionAttributeWindow = AttributeWindow.extend({
 	init: function(options, con) {
-		options.helpTarget = help_baseUrl+"/editor:configwindow_connection";
 		this._super(options);
 
 		var panels = $('<ul class="nav nav-tabs" style="margin-bottom: 1pt;"></ul>');

--- a/web/tomato/web_resources.py
+++ b/web/tomato/web_resources.py
@@ -1,3 +1,13 @@
+"""
+Web resources are resources that are only available to the webfrontend
+They are defined via a fixed URL that usually points to a JSON document.
+
+Current kinds of web resources:
+ - default executable archives
+ - custom element icons
+"""
+
+
 __author__ = 't-gerhard'
 
 import json, urllib2


### PR DESCRIPTION
Closes #1313
Errors in tasks are now dumped regardless of their actual setting
Fixed marking all account notifications read
Fixed an error in the backend problems manager
Editor help buttons now link to the new user manual [note: config.yaml: external-url.help should be updated]